### PR TITLE
Pass local variables to Rails templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ class Provider::EstimatesController < Provider::BaseController
                :formats => %w[pdf],
                :stylesheets => %w[application prince],
                :layout => 'pdf',
+               :locals => { :foo => 'bar' },
                :disposition => 'inline', # PDF will be sent inline, means you can load it inside an iFrame or Embed
                :relative_paths => true # Modify asset paths to make them relative. See [the AssetSupport module](/lib/princely/asset_support.rb)
       end
@@ -40,6 +41,7 @@ The defaults for the render options are as follows:
 
     layout:          false
     template:        the template for the current controller/action
+    locals:          none
     stylesheets:     none
     disposition:     attachment (created PDF file will be sent as download)
     relative_paths:  true

--- a/lib/princely/pdf_helper.rb
+++ b/lib/princely/pdf_helper.rb
@@ -34,7 +34,7 @@ module Princely
       # Sets style sheets on PDF renderer
       prince.add_style_sheets(*options[:stylesheets].collect{|style| asset_file_path(style)})
 
-      html_string = render_to_string(options.slice(:template, :layout, :handlers, :formats))
+      html_string = render_to_string(options.slice(:template, :layout, :handlers, :formats, :locals))
 
       html_string = localize_html_string(html_string, Rails.public_path) if options[:relative_paths]
 


### PR DESCRIPTION
We need this to simplify rendering print view's, it won't have a dependency on needing an instance variable to be present anymore.