### PR TITLE
Chore: PDFs should be correctly styled when viewed locally in develop…

### DIFF
--- a/lib/princely/asset_support.rb
+++ b/lib/princely/asset_support.rb
@@ -18,7 +18,7 @@ module Princely
       asset = asset.gsub(%r'/assets/', '')
 
       if Rails.application.assets
-        Rails.application.assets.find_asset(asset).try(:pathname) || asset
+        Rails.application.assets.find_asset(asset).try(:filename) || asset
       else
         path = view_context.asset_path(asset.concat('.css')) # asset filename, inc. hash, with relative path
           .scan(%r"#{Regexp.escape(asset.split('.').first)}[-0-9a-f]*?\.[a-z]+?$")


### PR DESCRIPTION
…ment

Because:
* It is a pain having to move css files into the public folder to work on styling pdfs.

This commit:
* Replaces the depreciated `pathname` method with the recommended `filename` method sprockets uses now.

[ch11364]